### PR TITLE
Fix remote model load URL

### DIFF
--- a/modules/esrgan_model.py
+++ b/modules/esrgan_model.py
@@ -39,9 +39,8 @@ class UpscalerESRGAN(Upscaler):
 
     def load_model(self, path: str):
         if path.startswith("http"):
-            # TODO: this doesn't use `path` at all?
             filename = modelloader.load_file_from_url(
-                url=self.model_url,
+                url=path,
                 model_dir=self.model_download_path,
                 file_name=f"{self.model_name}.pth",
             )


### PR DESCRIPTION
## Summary
- ensure remote models use the provided URL when loading ESRGAN upscaler models

## Testing
- `python -m py_compile modules/esrgan_model.py`

## Summary by Sourcery

Bug Fixes:
- Use the passed-in path as the URL when loading remote ESRGAN models instead of the default model_url