### PR TITLE
Suppress Triton warning

### DIFF
--- a/backend/memory_management.py
+++ b/backend/memory_management.py
@@ -5,10 +5,16 @@ import time
 import psutil
 import torch
 import platform
+import logging
 
 from enum import Enum
 from backend import stream, utils
 from backend.args import args
+
+# Suppress Triton-related warning emitted by xformers when Triton is not present
+logging.getLogger("xformers").addFilter(
+    lambda record: 'A matching Triton is not available' not in record.getMessage()
+)
 
 
 cpu = torch.device('cpu')


### PR DESCRIPTION
## Summary
- avoid `A matching Triton is not available` message by filtering xformers logger early

## Testing
- `python -m pip install pytest -q` *(fails: Could not find a version that satisfies the requirement pytest)*

## Summary by Sourcery

Enhancements:
- Add a logging filter to remove 'A matching Triton is not available' messages from xformers logs.