### PR TITLE
Add console accordion under txt2img output

### DIFF
--- a/modules/ui_common.py
+++ b/modules/ui_common.py
@@ -156,6 +156,7 @@ class OutputPanel:
     infotext = None
     html_log = None
     button_upscale = None
+    console = None
 
 
 def create_output_panel(tabname, outdir, toprow=None):
@@ -257,6 +258,10 @@ def create_output_panel(tabname, outdir, toprow=None):
                             res.html_log,
                         ]
                     )
+
+                if tabname == "txt2img":
+                    with gr.Accordion(label="Console", open=False, elem_id="txt2img_console"):
+                        res.console = gr.HTML(elem_id="console_txt2img")
 
             else:
                 res.generation_info = gr.HTML(elem_id=f'html_info_x_{tabname}')

--- a/script.js
+++ b/script.js
@@ -212,3 +212,17 @@ function uiElementInSight(el) {
 
     return isOnScreen;
 }
+
+// Capture console errors and display them in the txt2img console accordion
+window.sd_console_errors = [];
+const origConsoleError = console.error.bind(console);
+console.error = function(...args) {
+    origConsoleError(...args);
+    const msg = args.map(a => typeof a === 'object' ? JSON.stringify(a) : a).join(' ');
+    window.sd_console_errors.push(msg);
+    const app = gradioApp();
+    const el = app.querySelector('#txt2img_console');
+    if (el) {
+        el.innerText = window.sd_console_errors.join('\n');
+    }
+};


### PR DESCRIPTION
## Summary
- capture JS console errors and display them
- add console accordion below txt2img results

## Testing
- `ruff check .`
- `which pytest || echo 'pytest not installed'`
